### PR TITLE
feat(#68): Add `erf_dbg`

### DIFF
--- a/src/erf_dbg.erl
+++ b/src/erf_dbg.erl
@@ -1,0 +1,89 @@
+%%% Copyright 2024 Nomasystems, S.L. http://www.nomasystems.com
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+% @doc Eases debugging the erf-generated modules used for validating request
+% bodies.
+-module(erf_dbg).
+
+%%% EXTERNAL EXPORTS
+-export([
+    register/2,
+    trace/1,
+    untrace/1
+]).
+
+%%%-----------------------------------------------------------------------------
+%%% EXTERNAL EXPORTS
+%%%-----------------------------------------------------------------------------
+
+% @doc Registers an operation ID to module association. Doing such registering
+% is required for the `trace` method on this module to properly work. The
+% provided operation ID needs to be a string obtained by calling
+% `erf_util:to_snake_case`. This function is not to be called multiple times 
+-spec register(SnakeOperationId, Module) -> Result when
+    SnakeOperationId :: binary(),
+    Module :: module(),
+    Result :: ok.
+register(SnakeOperationId, Module) ->
+    ok = ensure_ets(),
+    true = ets:insert(?MODULE, {SnakeOperationId, Module}),
+    ok.
+
+% @doc Traces the module associated to the provided `OperationId`. For this to
+% work it is required that such association has been registered using the
+% `register` method on this module. 
+-spec trace(OperationId) -> Result when
+    OperationId :: string(),
+    Result :: not_found | {ok, MatchDesc},
+    MatchDesc :: [MatchInfo],
+    MatchInfo :: {saved, integer()} | MatchNum,
+    MatchNum :: {matched, node(), 1} | {matched, node(), 0, RPCError},
+    RPCError :: term().
+trace(OperationId) ->
+    SnakeOperationId = erf_util:to_snake_case(OperationId),
+    case ets:lookup(?MODULE, SnakeOperationId) of
+        [{_OperationId, Module}] ->
+            dbg:tracer(),
+            dbg:p(all, c),
+            dbg:tpl(Module, cx);
+        [] ->
+            not_found
+    end.
+
+% @doc Removes traces from the module associated to the provided `OperationId`.
+% Always returns `ok`.
+-spec untrace(OperationId) -> Result when
+    OperationId :: string(),
+    Result :: ok.
+untrace(OperationId) ->
+    SnakeOperationId = erf_util:to_snake_case(OperationId),
+    case ets:lookup(?MODULE, SnakeOperationId) of
+        [{_OperationId, Module}] ->
+            dbg:ctpl(Module, cx);
+        [] ->
+            ok
+    end,
+    ok.
+
+%%%-----------------------------------------------------------------------------
+%%% INTERNAL FUNCTIONS
+%%%-----------------------------------------------------------------------------
+ensure_ets() ->
+    case ets:whereis(?MODULE) of
+        undefined ->
+            ?MODULE = ets:new(?MODULE, [public, named_table]),
+            ok;
+        _ ->
+            ok
+    end.


### PR DESCRIPTION
Closes #68

Two comments on the provided solution:
- Even though the 3 exported functions on the provided module receive an operation ID as first parameter, the `register` function expects it on the same format as returned by the `erf_parser` module, while the other two functions expect it on the same format as the value on the user-provided OpenAPI spec. This should be object of discussion, because I feel the decision of snake-casing the operation ID to be used as ref to a request body schema/type should be a requirement when internally processing an operation ID and it's not properly documented. This will be specially relevant when documenting how to implement other spec parsers.
- IMO provided code eases debugging the right module, but I would like to bring up to discussion the adequateness of the function names on the generated validation modules when it comes to be associated to a particular part/path on the user-provided spec. For instance, the following `dbg` trace shows a call to the function that validates the first of the possible request body schemas on the  `createUser` operation of the `users.openapi.json` OpenAPI spec provided on the example.
```
(<0.711.0>) call users_openapi_create_user_request_body:'$.any_of[0]
```
I know that the '$.any_of' refers to the possible body schemas allowed for the operation, and that [0] means the first of them (this part about the [0] is not the one I'm concerned about), but I'm pretty sure I know this because I wrote a fair part of the code that puts their name on those functions. If we could find a better naming for those functions it would be great, specially for new devs coming to the project. Just wanted to let that written somewhere, even though I recognize that task is not easy and that we've discussed it enough at this point.