### PR TITLE
Prevent invalid responses

### DIFF
--- a/src/erf_router.erl
+++ b/src/erf_router.erl
@@ -252,7 +252,7 @@ handle_ast(API, #{callback := Callback} = Opts) ->
                     erl_syntax:clause(
                         [
                             erl_syntax:match_expr(
-                                erl_syntax:variable('Request'),
+                                erl_syntax:variable('Request0'),
                                 erl_syntax:map_expr(
                                     none,
                                     [
@@ -286,6 +286,18 @@ handle_ast(API, #{callback := Callback} = Opts) ->
                                 erl_syntax:variable('IsValidRequest'),
                                 IsValidRequestAST
                             ),
+                            erl_syntax:match_expr(
+                                erl_syntax:variable('Request'),
+                                erl_syntax:map_expr(
+                                    erl_syntax:variable('Request0'),
+                                    [
+                                        erl_syntax:map_field_assoc(
+                                            erl_syntax:atom('path_parameters'),
+                                            erl_syntax:variable('PathParameters')
+                                        )
+                                    ]
+                                )
+                            ),
                             erl_syntax:case_expr(
                                 erl_syntax:variable('IsValidRequest'),
                                 [
@@ -303,19 +315,7 @@ handle_ast(API, #{callback := Callback} = Opts) ->
                                                         utf8
                                                     )
                                                 ),
-                                                [
-                                                    erl_syntax:map_expr(
-                                                        erl_syntax:variable('Request'),
-                                                        [
-                                                            erl_syntax:map_field_assoc(
-                                                                erl_syntax:atom('path_parameters'),
-                                                                erl_syntax:variable(
-                                                                    'PathParameters'
-                                                                )
-                                                            )
-                                                        ]
-                                                    )
-                                                ]
+                                                [erl_syntax:variable('Request')]
                                             )
                                         ]
                                     ),
@@ -323,16 +323,17 @@ handle_ast(API, #{callback := Callback} = Opts) ->
                                         [
                                             erl_syntax:tuple([
                                                 erl_syntax:atom(false),
-                                                erl_syntax:variable('_Reason')
+                                                erl_syntax:variable('Reason')
                                             ])
                                         ],
                                         none,
                                         [
-                                            erl_syntax:tuple(
+                                            erl_syntax:application(
+                                                erl_syntax:atom(erf_util),
+                                                erl_syntax:atom(handle_invalid_request),
                                                 [
-                                                    erl_syntax:integer(400),
-                                                    erl_syntax:list([]),
-                                                    erl_syntax:atom(undefined)
+                                                    erl_syntax:variable('Request'),
+                                                    erl_syntax:variable('Reason')
                                                 ]
                                             )
                                         ]

--- a/src/erf_util.erl
+++ b/src/erf_util.erl
@@ -16,7 +16,8 @@
 %%% EXTERNAL EXPORTS
 -export([
     to_pascal_case/1,
-    to_snake_case/1
+    to_snake_case/1,
+    handle_invalid_request/2
 ]).
 
 %%%-----------------------------------------------------------------------------
@@ -86,3 +87,7 @@ to_snake_case([_C | Rest], [$_ | _T] = Acc) ->
     to_snake_case(Rest, Acc);
 to_snake_case([_C | Rest], Acc) ->
     to_snake_case(Rest, [$_ | Acc]).
+
+
+handle_invalid_request(_Request, Reason) ->
+    {400, [{<<"content-type">>, <<"text/plain">>}], [io_lib:print(Reason), "\n"]}.

--- a/src/erf_util.erl
+++ b/src/erf_util.erl
@@ -13,11 +13,14 @@
 %% limitations under the License
 -module(erf_util).
 
+-include_lib("kernel/include/logger.hrl").
+
 %%% EXTERNAL EXPORTS
 -export([
     to_pascal_case/1,
     to_snake_case/1,
-    handle_invalid_request/2
+    handle_invalid_request/2,
+    validate_response/3
 ]).
 
 %%%-----------------------------------------------------------------------------
@@ -91,3 +94,22 @@ to_snake_case([_C | Rest], Acc) ->
 
 handle_invalid_request(_Request, Reason) ->
     {400, [{<<"content-type">>, <<"text/plain">>}], [io_lib:print(Reason), "\n"]}.
+
+validate_response(Request, {Status, _, #{} = RespBody} = Response, Validators) ->
+    IsValid = case Validators of
+        #{Status := ValidatorMod} ->
+            ValidatorMod:is_valid(RespBody);
+        #{'*' := ValidatorMod} ->
+            ValidatorMod:is_valid(RespBody);
+        #{} ->
+            unknown_status
+    end,
+    case IsValid of
+        true ->
+            Response;
+        Other ->
+            ?LOG(error, "[erf] Bad response (~0p)~n  ~120p~n  for request ~120p", [Other, Response, Request]),
+            {500, [{<<"content-type">>, <<"text/plain">>}], <<"Internal server error">>}
+    end;
+validate_response(_Request, {_, _, _} = Response, _) ->
+    Response.

--- a/test/erf_SUITE.erl
+++ b/test/erf_SUITE.erl
@@ -101,7 +101,7 @@ foo(_Conf) ->
     ),
 
     ?assertMatch(
-        {ok, {{"HTTP/1.1", 400, "Bad Request"}, _Result2Headers, <<>>}},
+        {ok, {{"HTTP/1.1", 400, "Bad Request"}, _Result2Headers, <<_/binary>>}},
         httpc:request(
             post,
             {"http://localhost:8789/1/foo", [], "application/json", <<"\"foobar\"">>},

--- a/test/erf_router_SUITE.erl
+++ b/test/erf_router_SUITE.erl
@@ -166,7 +166,7 @@ foo(_Conf) ->
 
     meck:expect(get_foo_request_body, is_valid, fun(_Value) -> {false, reason} end),
 
-    ?assertEqual({400, [], undefined}, Mod:handle(Req)),
+    ?assertMatch({400, [{<<"content-type">>, _}], _}, Mod:handle(Req)),
 
     NotAllowedReq = #{
         path => [<<"1">>, <<"foo">>],


### PR DESCRIPTION
User code has errors.  
Do not allow these errors to cause troubles on client side.  
Crash early when response does not match schema.