### PR TITLE
feat: Handle preprocess errors

### DIFF
--- a/src/erf_router.erl
+++ b/src/erf_router.erl
@@ -117,30 +117,31 @@ handle(Name, RawRequest) ->
     {ok, PreProcessMiddlewares} = erf_conf:preprocess_middlewares(Name),
     {ok, RouterMod} = erf_conf:router_mod(Name),
     {ok, PostProcessMiddlewares} = erf_conf:postprocess_middlewares(Name),
-    case preprocess(RawRequest) of
-        {ok, Request} ->
-            {InitialResponse, InitialRequest} =
+    {InitialResponse, InitialRequest} =
+        case preprocess(RawRequest) of
+            {ok, Request} ->
                 case apply_preprocess_middlewares(Request, PreProcessMiddlewares) of
                     {stop, PreprocessResponse, PreprocessRequest} ->
                         {PreprocessResponse, PreprocessRequest};
                     PreprocessRequest ->
                         {RouterMod:handle(PreprocessRequest), PreprocessRequest}
-                end,
-            Response = apply_postprocess_middlewares(
-                InitialRequest, InitialResponse, PostProcessMiddlewares
-            ),
-            postprocess(InitialRequest, Response);
-        {error, _Reason} ->
-            ContentTypeHeader = string:casefold(<<"content-type">>),
-            ErrorBody = iolist_to_binary(
-                json:encode(#{
-                    <<"title">> => <<"Bad Request">>,
-                    <<"status">> => 400,
-                    <<"detail">> => <<"Failed to read request">>
-                })
-            ),
-            {400, [{ContentTypeHeader, <<"application/json">>}], ErrorBody}
-    end.
+                end;
+            {error, _Reason} ->
+                ContentTypeHeader = string:casefold(<<"content-type">>),
+                ErrorBody = iolist_to_binary(
+                    json:encode(#{
+                        <<"title">> => <<"Bad Request">>,
+                        <<"status">> => 400,
+                        <<"detail">> => <<"Failed to read request">>
+                    })
+                ),
+                ResponseError = {400, [{ContentTypeHeader, <<"application/json">>}], ErrorBody},
+                {ResponseError, RawRequest}
+        end,
+    Response = apply_postprocess_middlewares(
+        InitialRequest, InitialResponse, PostProcessMiddlewares
+    ),
+    postprocess(InitialRequest, Response).
 
 %%%-----------------------------------------------------------------------------
 %%% INTERNAL FUNCTIONS


### PR DESCRIPTION

 ## Summary
Reworks erf_router:handle/2 so that requests failing at the preprocess stage still flow through the postprocess middlewares and postprocess/1, instead of returning the raw 400 response early.

 ## Motivation
  Previously, when preprocess/1 failed (e.g. an unreadable request), handle/2 returned the 400 Bad Request response directly, bypassing apply_postprocess_middlewares/3 and postprocess/1. This caused two problems:

  - Postprocess middlewares (logging, metrics, header injection, etc.) never ran for malformed requests, leaving a gap in observability and inconsistent response handling.
  - The error response was returned as-is, with no chance to be handled by the postprocessing pipeline, so it could end up not matching the error shape defined in the OpenAPI spec.

 ## Changes
  - Moved the preprocess/1 case so it only computes the {InitialResponse, InitialRequest} pair.
  - On preprocess error, the 400 response is paired with the original RawRequest ({ResponseError, RawRequest}) so downstream stages have a valid request to work with.
  - apply_postprocess_middlewares/3 and postprocess/1 now run unconditionally for both the success and error paths.