### PR TITLE
feat: mount several API specifications on a single port

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,9 @@ The configuration is provided as map with the following type spec:
 ```erl
 %%% erf.erl
 -type conf() :: #{
-    spec_path := binary(),
-    callback := module(),
+    spec_path => binary(),
+    callback => module(),
+    mounts => [mount(), ...],
     port => inet:port_number(),
     name => atom(),
     spec_parser => module(),
@@ -171,6 +172,7 @@ The configuration is provided as map with the following type spec:
 A detailed description of each parameter can be found in the following list:
 - `spec_path` : Path to API specification file.
 - `callback`: Name of the callback module.
+- `mounts`: List of API specifications to serve, each under its own base path. Mutually exclusive with `spec_path` and `callback`.
 - `port`: Port the server will listen to. Defaults to `8080`.
 - `name`: Name under which the server is registered. Defaults to `erf`.
 - `spec_parser`: Name of the specification parser module. Defaults to `erf_parser_oas_3_0`.
@@ -188,6 +190,47 @@ A detailed description of each parameter can be found in the following list:
 - `body_timeout`: Timeout in ms for receiving more packets when waiting for the body. Defaults to `30000`.
 - `max_body_size`: Maximum size in bytes for the body of allowed received messages. Defaults to `1024000`.
 - `log_level`: Severity associated to logged messages. Defaults to `error`.
+
+## Mounts
+
+A single `erf` instance can serve several API specifications, each under its own base path. The type spec for a mount is the following:
+```erl
+%%% erf.erl
+-type base_path() :: binary().
+-type mount() :: #{
+    base_path := base_path(),
+    spec_path := binary(),
+    callback := module(),
+    spec_parser => module()
+}.
+```
+
+- `base_path`: Path prefix the mount is served under. `<<"/">>` serves it from the root.
+- `spec_path`: Path to the mount's API specification file.
+- `callback`: Name of the mount's callback module.
+- `spec_parser`: Name of the specification parser module. Defaults to the instance's `spec_parser`.
+
+```erl
+ShopAPIConf = #{
+    port => 8080,
+    mounts => [
+        #{
+            base_path => <<"/users">>,
+            spec_path => <<"priv/users.openapi.json">>,
+            callback => users_callback
+        },
+        #{
+            base_path => <<"/products">>,
+            spec_path => <<"priv/products.openapi.json">>,
+            callback => products_callback
+        }
+    ]
+}.
+```
+
+A `GET /users/1` request is validated against the `/1` route of `users.openapi.json` and dispatched to `users_callback`. The prefix is not stripped, so `path` and `route` keep describing the real URL. Mounts repeating a base path, or serving routes that can match the same request, are rejected when the instance starts.
+
+The `examples/shop` application serves [orders.openapi.json](examples/shop/priv/orders.openapi.json) from the root and [catalog.openapi.json](examples/shop/priv/catalog.openapi.json) from `/catalog`. Try it out by running `rebar3 as examples shell` from the root of this project.
 
 ## Callback modules & middlewares
 
@@ -212,6 +255,7 @@ The following type spec corresponds to the runtime configuration of an `erf` ins
 -type t() :: #{
     callback => module(),
     log_level => logger:level(),
+    mounts => [erf:mount(), ...],
     preprocess_middlewares => [module()],
     postprocess_middlewares => [module()],
     router => erl_syntax:syntaxTree(), % not manually updatable
@@ -224,6 +268,8 @@ The following type spec corresponds to the runtime configuration of an `erf` ins
 ```
 > __NOTE:__ the `router` and `router_mod` keys are not updatable as they are automatically computed when new configuration is provided.
 
+A reload replaces the [mounts](#mounts) of an instance when it carries `mounts`, or both `spec_path` and `callback`. Carrying only one of the latter two updates the mount already configured, and needs the instance to have a single one.
+
 ## Static routes
 
 As shown in [`erf` configuration](#erf-configuration), the server supports routes that serve static files. The type spec for static routes is the following:
@@ -234,7 +280,7 @@ As shown in [`erf` configuration](#erf-configuration), the server supports route
 -type static_route() :: {Path :: binary(), Resource :: static_file() | static_dir()}.
 ```
 
-This feature enables `erf` to serve a [Swagger UI](https://github.com/swagger-api/swagger-ui) version with your API specification. Just set the `swagger_ui` flag to `true` and open your web browser in the server host under the `/swagger` path.
+This feature enables `erf` to serve a [Swagger UI](https://github.com/swagger-api/swagger-ui) version with your API specification. Just set the `swagger_ui` flag to `true` and open your web browser in the server host under the `/swagger` path. Each [mount](#mounts) gets its own UI under its base path.
 
 ## Troubleshooting
 

--- a/examples/shop/priv/catalog.openapi.json
+++ b/examples/shop/priv/catalog.openapi.json
@@ -1,0 +1,138 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Catalog REST API",
+    "version": "1.0.0",
+    "description": "A REST API for a simple product catalog service."
+  },
+  "paths": {
+    "/products": {
+      "get": {
+        "operationId": "listProducts",
+        "summary": "Lists the products",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Product"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createProduct",
+        "summary": "Creates a Product",
+        "requestBody": {
+          "description": "A product creation request",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "price": {
+                    "type": "number",
+                    "minimum": 0
+                  }
+                },
+                "required": [
+                  "name",
+                  "price"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Product"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/products/{productId}": {
+      "parameters": [
+        {
+          "name": "productId",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getProduct",
+        "summary": "Gets a Product",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Product"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Product": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "price": {
+            "type": "number",
+            "minimum": 0
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/shop/priv/orders.openapi.json
+++ b/examples/shop/priv/orders.openapi.json
@@ -1,0 +1,136 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Orders REST API",
+    "version": "1.0.0",
+    "description": "A REST API for a simple order management service."
+  },
+  "paths": {
+    "/orders": {
+      "get": {
+        "operationId": "listOrders",
+        "summary": "Lists the orders",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Order"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createOrder",
+        "summary": "Creates an Order",
+        "requestBody": {
+          "description": "An order creation request",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "productId": {
+                    "type": "string"
+                  },
+                  "units": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                },
+                "required": [
+                  "productId",
+                  "units"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/orders/{orderId}": {
+      "parameters": [
+        {
+          "name": "orderId",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ],
+      "get": {
+        "operationId": "getOrder",
+        "summary": "Gets an Order",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "productId": {
+            "type": "string"
+          },
+          "units": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/shop/src/shop.app.src
+++ b/examples/shop/src/shop.app.src
@@ -1,0 +1,8 @@
+{application, shop, [
+    {description, "A tiny app exemplifying erf mounts"},
+    {vsn, "0.1.0"},
+    {registered, []},
+    {applications, [kernel, stdlib, erf]},
+    {mod, {shop, []}},
+    {env, []}
+]}.

--- a/examples/shop/src/shop.erl
+++ b/examples/shop/src/shop.erl
@@ -1,0 +1,11 @@
+-module(shop).
+
+-behaviour(application).
+
+-export([start/2, stop/1]).
+
+start(_StartType, _StartArgs) ->
+    shop_sup:start_link().
+
+stop(_State) ->
+    ok.

--- a/examples/shop/src/shop_catalog_callback.erl
+++ b/examples/shop/src/shop_catalog_callback.erl
@@ -1,0 +1,30 @@
+%% An <code>erf</code> callback for the catalog mount, served from `/catalog'.
+-module(shop_catalog_callback).
+
+%%% EXTERNAL EXPORTS
+-export([
+    list_products/1,
+    create_product/1,
+    get_product/1
+]).
+
+%%%-------------------------------------------------------
+%%% EXTERNAL EXPORTS
+%%%-------------------------------------------------------
+list_products(_Request) ->
+    {200, [], [Product || {_Id, Product} <- ets:tab2list(products)]}.
+
+create_product(#{body := Body} = _Request) ->
+    Id = base64:encode(crypto:strong_rand_bytes(16), #{mode => urlsafe, padding => false}),
+    Product = Body#{<<"id">> => Id},
+    ets:insert(products, {Id, Product}),
+    {201, [], Product}.
+
+get_product(#{path_parameters := PathParameters} = _Request) ->
+    Id = proplists:get_value(<<"productId">>, PathParameters),
+    case ets:lookup(products, Id) of
+        [] ->
+            {404, [], #{<<"message">> => <<"Product ", Id/binary, " not found">>}};
+        [{Id, Product}] ->
+            {200, [], Product}
+    end.

--- a/examples/shop/src/shop_orders_callback.erl
+++ b/examples/shop/src/shop_orders_callback.erl
@@ -1,0 +1,30 @@
+%% An <code>erf</code> callback for the orders mount, served from the root.
+-module(shop_orders_callback).
+
+%%% EXTERNAL EXPORTS
+-export([
+    list_orders/1,
+    create_order/1,
+    get_order/1
+]).
+
+%%%-------------------------------------------------------
+%%% EXTERNAL EXPORTS
+%%%-------------------------------------------------------
+list_orders(_Request) ->
+    {200, [], [Order || {_Id, Order} <- ets:tab2list(orders)]}.
+
+create_order(#{body := Body} = _Request) ->
+    Id = base64:encode(crypto:strong_rand_bytes(16), #{mode => urlsafe, padding => false}),
+    Order = Body#{<<"id">> => Id},
+    ets:insert(orders, {Id, Order}),
+    {201, [], Order}.
+
+get_order(#{path_parameters := PathParameters} = _Request) ->
+    Id = proplists:get_value(<<"orderId">>, PathParameters),
+    case ets:lookup(orders, Id) of
+        [] ->
+            {404, [], #{<<"message">> => <<"Order ", Id/binary, " not found">>}};
+        [{Id, Order}] ->
+            {200, [], Order}
+    end.

--- a/examples/shop/src/shop_sup.erl
+++ b/examples/shop/src/shop_sup.erl
@@ -1,0 +1,48 @@
+-module(shop_sup).
+
+%%% BEHAVIOURS
+-behaviour(supervisor).
+
+%%% START/STOP EXPORTS
+-export([start_link/0]).
+
+%%% INTERNAL EXPORTS
+-export([init/1]).
+
+%%%-------------------------------------------------------
+%%% START/STOP EXPORTS
+%%%-------------------------------------------------------
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%%%-------------------------------------------------------
+%%% INTERNAL EXPORTS
+%%%-------------------------------------------------------
+init([]) ->
+    ets:new(orders, [public, named_table]),
+    ets:new(products, [public, named_table]),
+    ShopAPIConf = #{
+        mounts => [
+            #{
+                base_path => <<"/">>,
+                spec_path => filename:join(code:priv_dir(shop), <<"orders.openapi.json">>),
+                callback => shop_orders_callback
+            },
+            #{
+                base_path => <<"/catalog">>,
+                spec_path => filename:join(code:priv_dir(shop), <<"catalog.openapi.json">>),
+                callback => shop_catalog_callback
+            }
+        ],
+        swagger_ui => true,
+        port => 8081
+    },
+    ShopChildSpec = {
+        shop_api_server,
+        {erf, start_link, [ShopAPIConf]},
+        permanent,
+        5000,
+        worker,
+        [erf]
+    },
+    {ok, {{one_for_one, 5, 10}, [ShopChildSpec]}}.

--- a/priv/swagger-ui/index.html
+++ b/priv/swagger-ui/index.html
@@ -16,8 +16,9 @@
   <script src="https://unpkg.com/swagger-ui-dist@4.5.0/swagger-ui-standalone-preset.js" crossorigin></script>
   <script>
     window.onload = () => {
+      const base = window.location.pathname.replace(/\/$/, '');
       window.ui = SwaggerUIBundle({
-        url: '/swagger/spec.json',
+        url: base + '/spec.json',
         dom_id: '#swagger-ui',
         presets: [
           SwaggerUIBundle.presets.apis

--- a/rebar.config
+++ b/rebar.config
@@ -33,9 +33,9 @@
 
 {profiles, [
     {examples, [
-        {project_app_dirs, ["examples/users", "."]},
+        {project_app_dirs, ["examples/users", "examples/shop", "."]},
         {shell, [
-            {apps, [users]}
+            {apps, [users, shop]}
         ]}
     ]},
     {test, [

--- a/src/erf.erl
+++ b/src/erf.erl
@@ -42,10 +42,12 @@
 
 %%% TYPES
 -type api() :: erf_parser:api().
+-type base_path() :: binary().
 -type body() :: undefined | json:decode_value().
 -type conf() :: #{
-    spec_path := binary(),
-    callback := module(),
+    spec_path => binary(),
+    callback => module(),
+    mounts => [mount(), ...],
     port => inet:port_number(),
     name => atom(),
     spec_parser => module(),
@@ -69,6 +71,12 @@
     | options
     | trace
     | connect.
+-type mount() :: #{
+    base_path := base_path(),
+    spec_path := binary(),
+    callback := module(),
+    spec_parser => module()
+}.
 -type path_parameter() :: {binary(), binary()}.
 -type query_parameter() :: {binary(), binary()}.
 -type request() :: #{
@@ -101,10 +109,12 @@
 %%% TYPE EXPORTS
 -export_type([
     api/0,
+    base_path/0,
     body/0,
     conf/0,
     header/0,
     method/0,
+    mount/0,
     path_parameter/0,
     query_parameter/0,
     request/0,
@@ -205,23 +215,18 @@ reload_conf(Name, NewConf) ->
                 Old
         end,
 
-    Conf = maps:merge(OldConf, NewConf),
+    RawConf = maps:merge(OldConf, NewConf),
 
-    SpecPath = maps:get(spec_path, Conf),
-    SpecParser = maps:get(spec_parser, Conf),
-    Callback = maps:get(callback, Conf),
-    StaticRoutes = maps:get(static_routes, Conf),
-    SwaggerUI = maps:get(swagger_ui, Conf),
-
-    case build_router(SpecPath, SpecParser, Callback, StaticRoutes, SwaggerUI) of
-        {ok, RouterMod, Router, API} ->
-            RoutePatterns = route_patterns(API, StaticRoutes, SwaggerUI),
-            erf_conf:set(Name, Conf#{
-                route_patterns => RoutePatterns,
-                router_mod => RouterMod,
-                router => Router
-            }),
-            ok;
+    case reload_mounts(NewConf, RawConf) of
+        {ok, Mounts} ->
+            Conf = with_mounts(RawConf, Mounts),
+            case build_router(Conf) of
+                {ok, Extras} ->
+                    erf_conf:set(Name, maps:merge(Conf, Extras)),
+                    ok;
+                {error, Reason} ->
+                    {error, Reason}
+            end;
         {error, Reason} ->
             {error, Reason}
     end.
@@ -230,53 +235,48 @@ reload_conf(Name, NewConf) ->
 %%% INIT/TERMINATE EXPORTS
 %%%-----------------------------------------------------------------------------
 init([Name, RawConf]) ->
-    RawErfConf = #{
-        spec_path => maps:get(spec_path, RawConf),
-        spec_parser => maps:get(spec_parser, RawConf, erf_parser_oas_3_0),
-        callback => maps:get(callback, RawConf),
-        static_routes => maps:get(static_routes, RawConf, []),
-        swagger_ui => maps:get(swagger_ui, RawConf, false),
-        preprocess_middlewares => maps:get(preprocess_middlewares, RawConf, []),
-        postprocess_middlewares => maps:get(postprocess_middlewares, RawConf, []),
-        log_level => maps:get(log_level, RawConf, error)
-    },
-
-    SpecPath = maps:get(spec_path, RawErfConf),
-    SpecParser = maps:get(spec_parser, RawErfConf),
-    Callback = maps:get(callback, RawErfConf),
-    StaticRoutes = maps:get(static_routes, RawErfConf),
-    SwaggerUI = maps:get(swagger_ui, RawErfConf),
-
-    case build_router(SpecPath, SpecParser, Callback, StaticRoutes, SwaggerUI) of
-        {ok, RouterMod, Router, API} ->
-            RoutePatterns = route_patterns(API, StaticRoutes, SwaggerUI),
-            ErfConf = RawErfConf#{
-                route_patterns => RoutePatterns,
-                router_mod => RouterMod,
-                router => Router
-            },
-            ok = erf_conf:set(Name, ErfConf),
-
-            {HTTPServer, HTTPServerExtraConf} = maps:get(
-                http_server, RawConf, {erf_http_server_elli, #{}}
+    case mounts(RawConf) of
+        {ok, Mounts} ->
+            RawErfConf = with_mounts(
+                #{
+                    spec_parser => maps:get(spec_parser, RawConf, erf_parser_oas_3_0),
+                    static_routes => maps:get(static_routes, RawConf, []),
+                    swagger_ui => maps:get(swagger_ui, RawConf, false),
+                    preprocess_middlewares => maps:get(preprocess_middlewares, RawConf, []),
+                    postprocess_middlewares => maps:get(postprocess_middlewares, RawConf, []),
+                    log_level => maps:get(log_level, RawConf, error)
+                },
+                Mounts
             ),
-            HTTPServerConf = build_http_server_conf(RawConf),
-            SupFlags = #{
-                strategy => one_for_one,
-                intensity => 1,
-                period => 5
-            },
-            ChildSpec = {
-                Name,
-                {erf_http_server, start_link, [
-                    HTTPServer, HTTPServerExtraConf, Name, HTTPServerConf
-                ]},
-                permanent,
-                5000,
-                worker,
-                [erf_http_server]
-            },
-            {ok, {SupFlags, [ChildSpec]}};
+
+            case build_router(RawErfConf) of
+                {ok, Extras} ->
+                    ErfConf = maps:merge(RawErfConf, Extras),
+                    ok = erf_conf:set(Name, ErfConf),
+
+                    {HTTPServer, HTTPServerExtraConf} = maps:get(
+                        http_server, RawConf, {erf_http_server_elli, #{}}
+                    ),
+                    HTTPServerConf = build_http_server_conf(RawConf),
+                    SupFlags = #{
+                        strategy => one_for_one,
+                        intensity => 1,
+                        period => 5
+                    },
+                    ChildSpec = {
+                        Name,
+                        {erf_http_server, start_link, [
+                            HTTPServer, HTTPServerExtraConf, Name, HTTPServerConf
+                        ]},
+                        permanent,
+                        5000,
+                        worker,
+                        [erf_http_server]
+                    },
+                    {ok, {SupFlags, [ChildSpec]}};
+                {error, Reason} ->
+                    {stop, Reason}
+            end;
         {error, Reason} ->
             {stop, Reason}
     end.
@@ -317,51 +317,41 @@ build_http_server_conf(ErfConf) ->
         keyfile => maps:get(keyfile, ErfConf, undefined)
     }.
 
--spec build_router(SpecPath, SpecParser, Callback, StaticRoutes, SwaggerUI) -> Result when
-    SpecPath :: binary(),
-    SpecParser :: module(),
-    Callback :: module(),
-    StaticRoutes :: [static_route()],
-    SwaggerUI :: boolean(),
-    Result :: {ok, RouterMod, Router, API} | {error, Reason},
-    RouterMod :: module(),
-    Router :: erl_syntax:syntaxTree(),
-    API :: api(),
+-spec build_router(Conf) -> Result when
+    Conf :: erf_conf:t(),
+    Result :: {ok, Extras} | {error, Reason},
+    Extras :: #{
+        route_patterns := route_patterns(),
+        router_mod := module(),
+        router := erl_syntax:syntaxTree()
+    },
     Reason :: term().
-build_router(SpecPath, SpecParser, Callback, RawStaticRoutes, SwaggerUI) ->
-    case erf_parser:parse(SpecPath, SpecParser) of
+build_router(Conf) ->
+    Mounts = maps:get(mounts, Conf),
+    RawStaticRoutes = maps:get(static_routes, Conf),
+    SwaggerUI = maps:get(swagger_ui, Conf),
+
+    case parse_api(Mounts) of
         {ok, API} ->
             Schemas = maps:to_list(maps:get(schemas, API)),
             case build_dtos(Schemas) of
                 ok ->
-                    StaticRoutes =
-                        case SwaggerUI of
-                            true ->
-                                IndexHTML =
-                                    case code:priv_dir(erf) of
-                                        {error, bad_name} ->
-                                            {error, <<"Cannot build `swagger-ui`">>};
-                                        Priv ->
-                                            filename:join([Priv, <<"swagger-ui">>, <<"index.html">>])
-                                    end,
-                                [
-                                    {<<"/swagger">>, {file, IndexHTML}},
-                                    {<<"/swagger/spec.json">>, {file, SpecPath}}
-                                    | RawStaticRoutes
-                                ];
-                            _False ->
-                                RawStaticRoutes
-                        end,
+                    StaticRoutes = swagger_routes(Mounts, SwaggerUI) ++ RawStaticRoutes,
                     {RouterMod, Router} = erf_router:generate(API, #{
-                        callback => Callback,
+                        callback => callbacks(Mounts),
                         static_routes => StaticRoutes
                     }),
+                    Extras = #{
+                        route_patterns => route_patterns(API, StaticRoutes),
+                        router_mod => RouterMod,
+                        router => Router
+                    },
                     case erf_router:load(Router) of
                         ok ->
-                            {ok, RouterMod, Router, API};
+                            {ok, Extras};
                         {ok, Warnings} ->
                             log_warnings(Warnings, <<"router generation">>),
-                            {ok, RouterMod, Router, API};
+                            {ok, Extras};
                         error ->
                             {error, {router_loading_failed, [unknown_error]}};
                         {error, {Errors, Warnings}} ->
@@ -374,6 +364,428 @@ build_router(SpecPath, SpecParser, Callback, RawStaticRoutes, SwaggerUI) ->
         {error, Reason} ->
             {error, Reason}
     end.
+
+-spec callbacks(Mounts) -> Callbacks when
+    Mounts :: [mount(), ...],
+    Callbacks :: #{base_path() => module()}.
+callbacks(Mounts) ->
+    maps:from_list([
+        {maps:get(base_path, Mount), maps:get(callback, Mount)}
+     || Mount <- Mounts
+    ]).
+
+-spec mounts(Conf) -> Result when
+    Conf :: conf() | erf_conf:t(),
+    Result :: {ok, Mounts} | {error, Reason},
+    Mounts :: [mount(), ...],
+    Reason :: term().
+%% @doc Normalises the specification config into a list of mounts, so that a single
+%% specification is just a single mount at the root.
+mounts(#{mounts := _Mounts, spec_path := _SpecPath}) ->
+    {error, {invalid_conf, mounts_and_spec_path}};
+mounts(#{mounts := _Mounts, callback := _Callback}) ->
+    {error, {invalid_conf, mounts_and_callback}};
+mounts(#{mounts := []}) ->
+    {error, {invalid_conf, empty_mounts}};
+mounts(#{mounts := Mounts} = Conf) when is_list(Mounts) ->
+    normalize_mounts(Mounts, default_spec_parser(Conf), [], []);
+mounts(#{spec_path := SpecPath, callback := Callback} = Conf) ->
+    normalize_mounts(
+        [#{base_path => <<"/">>, spec_path => SpecPath, callback => Callback}],
+        default_spec_parser(Conf),
+        [],
+        []
+    );
+mounts(_Conf) ->
+    {error, {invalid_conf, missing_spec_path}}.
+
+-spec with_mounts(Conf, Mounts) -> NewConf when
+    Conf :: erf_conf:t(),
+    Mounts :: [mount(), ...],
+    NewConf :: erf_conf:t().
+%% @doc Stores the normalised mounts in a configuration. An instance serving a single
+%% specification from the root keeps `spec_path' and `callback' alongside them, so that a
+%% configuration that never mentions `mounts' reads back exactly as it always has.
+with_mounts(Conf, [#{base_path := <<>>, spec_path := SpecPath, callback := Callback}] = Mounts) ->
+    Conf#{mounts => Mounts, spec_path => SpecPath, callback => Callback};
+with_mounts(Conf, Mounts) ->
+    (maps:without([spec_path, callback], Conf))#{mounts => Mounts}.
+
+-spec reload_mounts(NewConf, RawConf) -> Result when
+    NewConf :: erf_conf:t(),
+    RawConf :: erf_conf:t(),
+    Result :: {ok, Mounts} | {error, Reason},
+    Mounts :: [mount(), ...],
+    Reason :: term().
+%% @doc Resolves the mounts of a reloaded configuration. A reload carrying `mounts' replaces
+%% the stored ones wholesale, while one carrying `spec_path' or `callback' patches the only
+%% mount already configured, which is how an instance serving one specification swaps its
+%% callback module.
+%% The stored configuration of a single-specification instance carries `spec_path' and
+%% `callback' next to its `mounts', so the exclusivity between the two shapes is checked
+%% against what the reload itself brings, never against the merged configuration.
+reload_mounts(NewConf, RawConf) ->
+    HasMounts = maps:is_key(mounts, NewConf),
+    HasSingleSpec = maps:is_key(spec_path, NewConf) orelse maps:is_key(callback, NewConf),
+    case {HasMounts, HasSingleSpec} of
+        {true, true} ->
+            mounts(NewConf);
+        {true, false} ->
+            mounts(maps:without([spec_path, callback], RawConf));
+        {false, true} ->
+            patch_mount(NewConf, RawConf);
+        {false, false} ->
+            stored_mounts(RawConf)
+    end.
+
+-spec stored_mounts(RawConf) -> Result when
+    RawConf :: erf_conf:t(),
+    Result :: {ok, Mounts} | {error, Reason},
+    Mounts :: [mount(), ...],
+    Reason :: term().
+%% @doc Returns the mounts a reload that brings no specification config of its own must keep.
+%% They are already normalised, unless nothing has been configured for this instance yet.
+stored_mounts(#{mounts := Mounts}) ->
+    {ok, Mounts};
+stored_mounts(RawConf) ->
+    mounts(RawConf).
+
+-spec patch_mount(NewConf, RawConf) -> Result when
+    NewConf :: erf_conf:t(),
+    RawConf :: erf_conf:t(),
+    Result :: {ok, Mounts} | {error, Reason},
+    Mounts :: [mount(), ...],
+    Reason :: term().
+patch_mount(#{spec_path := SpecPath, callback := Callback}, RawConf) ->
+    normalize_mounts(
+        [#{base_path => <<"/">>, spec_path => SpecPath, callback => Callback}],
+        default_spec_parser(RawConf),
+        [],
+        []
+    );
+patch_mount(NewConf, RawConf) ->
+    Patch = maps:with([spec_path, callback, spec_parser], NewConf),
+    case maps:get(mounts, RawConf, undefined) of
+        undefined ->
+            mounts(RawConf);
+        [Mount] ->
+            normalize_mounts(
+                [maps:merge(Mount, Patch)], default_spec_parser(RawConf), [], []
+            );
+        _Mounts ->
+            {error, {invalid_conf, ambiguous_mount_patch}}
+    end.
+
+-spec default_spec_parser(Conf) -> SpecParser when
+    Conf :: conf() | erf_conf:t(),
+    SpecParser :: module().
+default_spec_parser(Conf) ->
+    maps:get(spec_parser, Conf, erf_parser_oas_3_0).
+
+-spec normalize_mounts(Mounts, DefaultSpecParser, SeenBasePaths, Acc) -> Result when
+    Mounts :: [mount()],
+    DefaultSpecParser :: module(),
+    SeenBasePaths :: [base_path()],
+    Acc :: [mount()],
+    Result :: {ok, [mount()]} | {error, Reason},
+    Reason :: term().
+normalize_mounts([], _DefaultSpecParser, _SeenBasePaths, Acc) ->
+    {ok, lists:reverse(Acc)};
+normalize_mounts([Mount | Rest], DefaultSpecParser, SeenBasePaths, Acc) ->
+    case normalize_mount(Mount, DefaultSpecParser) of
+        {ok, #{base_path := BasePath} = NormalizedMount} ->
+            case lists:member(BasePath, SeenBasePaths) of
+                true ->
+                    {error, {duplicate_base_path, BasePath}};
+                false ->
+                    normalize_mounts(
+                        Rest,
+                        DefaultSpecParser,
+                        [BasePath | SeenBasePaths],
+                        [NormalizedMount | Acc]
+                    )
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec normalize_mount(Mount, DefaultSpecParser) -> Result when
+    Mount :: mount(),
+    DefaultSpecParser :: module(),
+    Result :: {ok, mount()} | {error, Reason},
+    Reason :: term().
+normalize_mount(
+    #{base_path := RawBasePath, spec_path := SpecPath, callback := Callback} = Mount,
+    DefaultSpecParser
+) when is_binary(RawBasePath), is_binary(SpecPath), is_atom(Callback) ->
+    case normalize_base_path(RawBasePath) of
+        {ok, BasePath} ->
+            {ok, #{
+                base_path => BasePath,
+                spec_path => SpecPath,
+                callback => Callback,
+                spec_parser => maps:get(spec_parser, Mount, DefaultSpecParser)
+            }};
+        {error, Reason} ->
+            {error, Reason}
+    end;
+normalize_mount(Mount, _DefaultSpecParser) ->
+    {error, {invalid_mount, Mount}}.
+
+-spec normalize_base_path(RawBasePath) -> Result when
+    RawBasePath :: binary(),
+    Result :: {ok, base_path()} | {error, Reason},
+    Reason :: term().
+%% @doc Canonicalises a base path so that the root is the empty binary and every other base
+%% path has a leading and no trailing slash, making it a prefix that can be prepended as is.
+normalize_base_path(RawBasePath) ->
+    Segments = path_segments(RawBasePath),
+    case lists:any(fun is_path_parameter/1, Segments) of
+        true ->
+            {error, {invalid_base_path, RawBasePath}};
+        false ->
+            {ok, erlang:iolist_to_binary([[<<"/">>, Segment] || Segment <- Segments])}
+    end.
+
+-spec parse_api(Mounts) -> Result when
+    Mounts :: [mount(), ...],
+    Result :: {ok, API} | {error, Reason},
+    API :: api(),
+    Reason :: term().
+%% @doc Parses the specification of every mount and merges them into a single API AST whose
+%% endpoints are prefixed by, and tagged with, the base path they are mounted under.
+parse_api(Mounts) ->
+    case parse_mounts(Mounts, []) of
+        {ok, ParsedMounts} ->
+            merge_apis(ParsedMounts);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec parse_mounts(Mounts, Acc) -> Result when
+    Mounts :: [mount()],
+    Acc :: [{mount(), api()}],
+    Result :: {ok, [{mount(), api()}]} | {error, Reason},
+    Reason :: term().
+parse_mounts([], Acc) ->
+    {ok, lists:reverse(Acc)};
+parse_mounts([Mount | Rest], Acc) ->
+    SpecPath = maps:get(spec_path, Mount),
+    SpecParser = maps:get(spec_parser, Mount),
+    case erf_parser:parse(SpecPath, SpecParser) of
+        {ok, API} ->
+            parse_mounts(Rest, [{Mount, API} | Acc]);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec merge_apis(ParsedMounts) -> Result when
+    ParsedMounts :: [{mount(), api()}, ...],
+    Result :: {ok, API} | {error, Reason},
+    API :: api(),
+    Reason :: term().
+%% @doc Merges the APIs parsed from every mount into a single API AST. The parser already
+%% namespaces the schemas it generates by the specification's file name, so references are
+%% only renamed for the mounts whose specifications share a file name with another mount's.
+merge_apis([{_FirstMount, FirstAPI} | _Rest] = ParsedMounts) ->
+    Ambiguous = ambiguous_spec_names(ParsedMounts),
+    PrefixedAPIs = [
+        prefix_api(Mount, API, lists:member(spec_name(Mount), Ambiguous))
+     || {Mount, API} <- ParsedMounts
+    ],
+    Endpoints = lists:flatmap(fun(API) -> maps:get(endpoints, API) end, PrefixedAPIs),
+    case conflicting_routes(PrefixedAPIs) of
+        {ok, Path, OtherPath} ->
+            {error, {conflicting_routes, Path, OtherPath}};
+        none ->
+            Schemas = lists:foldl(
+                fun(API, Acc) -> maps:merge(Acc, maps:get(schemas, API)) end,
+                #{},
+                PrefixedAPIs
+            ),
+            {ok, FirstAPI#{endpoints => Endpoints, schemas => Schemas}}
+    end.
+
+-spec prefix_api(Mount, API, PrefixRefs) -> NewAPI when
+    Mount :: mount(),
+    API :: api(),
+    PrefixRefs :: boolean(),
+    NewAPI :: api().
+prefix_api(#{base_path := BasePath}, API, PrefixRefs) ->
+    Prefix =
+        case PrefixRefs of
+            true -> ref_prefix(BasePath);
+            false -> undefined
+        end,
+    Endpoints = [
+        (rewrite_refs(Prefix, Endpoint))#{
+            path => <<BasePath/binary, (maps:get(path, Endpoint))/binary>>,
+            base_path => BasePath
+        }
+     || Endpoint <- maps:get(endpoints, API)
+    ],
+    Schemas = maps:fold(
+        fun(Ref, Schema, Acc) ->
+            Acc#{prefix_ref(Prefix, Ref) => rewrite_refs(Prefix, Schema)}
+        end,
+        #{},
+        maps:get(schemas, API)
+    ),
+    API#{endpoints => Endpoints, schemas => Schemas}.
+
+-spec ambiguous_spec_names(ParsedMounts) -> SpecNames when
+    ParsedMounts :: [{mount(), api()}],
+    SpecNames :: [binary()].
+%% @doc Returns the specification file names used by more than one mount, whose generated
+%% schema references would otherwise collide.
+ambiguous_spec_names(ParsedMounts) ->
+    Counts = lists:foldl(
+        fun({Mount, _API}, Acc) ->
+            SpecName = spec_name(Mount),
+            Acc#{SpecName => maps:get(SpecName, Acc, 0) + 1}
+        end,
+        #{},
+        ParsedMounts
+    ),
+    [SpecName || SpecName := Count <- Counts, Count > 1].
+
+-spec spec_name(Mount) -> SpecName when
+    Mount :: mount(),
+    SpecName :: binary().
+spec_name(#{spec_path := SpecPath}) ->
+    filename:rootname(filename:basename(SpecPath)).
+
+-spec conflicting_routes(PrefixedAPIs) -> Result when
+    PrefixedAPIs :: [api()],
+    Result :: {ok, Path, OtherPath} | none,
+    Path :: binary(),
+    OtherPath :: binary().
+%% @doc Finds two routes belonging to different mounts that can match the same
+%% request, which the generated router would silently resolve by clause order. Routes within
+%% a single specification are left alone: a specification is free to shadow, say,
+%% `/items/{id}' with `/items/latest', and the more specific one is expected to win.
+conflicting_routes([]) ->
+    none;
+conflicting_routes([API | Rest]) ->
+    Paths = [maps:get(path, Endpoint) || Endpoint <- maps:get(endpoints, API)],
+    OtherPaths = [
+        maps:get(path, Endpoint)
+     || OtherAPI <- Rest, Endpoint <- maps:get(endpoints, OtherAPI)
+    ],
+    Conflicts = [
+        {Path, OtherPath}
+     || Path <- Paths, OtherPath <- OtherPaths, paths_conflict(Path, OtherPath)
+    ],
+    case Conflicts of
+        [{Path, OtherPath} | _Rest] ->
+            {ok, Path, OtherPath};
+        [] ->
+            conflicting_routes(Rest)
+    end.
+
+-spec paths_conflict(Path, OtherPath) -> Conflict when
+    Path :: binary(),
+    OtherPath :: binary(),
+    Conflict :: boolean().
+paths_conflict(Path, OtherPath) ->
+    Segments = path_segments(Path),
+    OtherSegments = path_segments(OtherPath),
+    erlang:length(Segments) =:= erlang:length(OtherSegments) andalso
+        lists:all(
+            fun({Segment, OtherSegment}) ->
+                Segment =:= OtherSegment orelse
+                    is_path_parameter(Segment) orelse
+                    is_path_parameter(OtherSegment)
+            end,
+            lists:zip(Segments, OtherSegments)
+        ).
+
+-spec path_segments(Path) -> Segments when
+    Path :: binary(),
+    Segments :: [binary()].
+path_segments(Path) ->
+    [Segment || Segment <- binary:split(Path, <<"/">>, [global]), Segment =/= <<>>].
+
+-spec is_path_parameter(Segment) -> IsPathParameter when
+    Segment :: binary(),
+    IsPathParameter :: boolean().
+is_path_parameter(<<"{", _Rest/binary>>) ->
+    true;
+is_path_parameter(_Segment) ->
+    false.
+
+-spec rewrite_refs(Prefix, Term) -> NewTerm when
+    Prefix :: binary() | undefined,
+    Term :: term(),
+    NewTerm :: term().
+%% @doc Recursively walks an API AST fragment, namespacing every `ref' field it finds
+%% (schema/parameter/body references) no matter how deeply nested it is, inside object
+%% properties, array items, oneOf/anyOf branches and so on.
+rewrite_refs(undefined, Term) ->
+    Term;
+rewrite_refs(Prefix, Term) when is_map(Term) ->
+    maps:fold(
+        fun
+            (ref, Ref, Acc) when is_binary(Ref) ->
+                Acc#{ref => prefix_ref(Prefix, Ref)};
+            (Key, Value, Acc) ->
+                Acc#{Key => rewrite_refs(Prefix, Value)}
+        end,
+        #{},
+        Term
+    );
+rewrite_refs(Prefix, Term) when is_list(Term) ->
+    [rewrite_refs(Prefix, Item) || Item <- Term];
+rewrite_refs(_Prefix, Term) ->
+    Term.
+
+-spec prefix_ref(Prefix, Ref) -> NewRef when
+    Prefix :: binary() | undefined,
+    Ref :: erf_parser:ref(),
+    NewRef :: erf_parser:ref().
+prefix_ref(undefined, Ref) ->
+    Ref;
+prefix_ref(Prefix, Ref) ->
+    <<Prefix/binary, "_", Ref/binary>>.
+
+-spec ref_prefix(BasePath) -> Prefix when
+    BasePath :: base_path(),
+    Prefix :: binary().
+%% @doc Turns a base path into a valid prefix for a generated schema reference.
+ref_prefix(<<>>) ->
+    <<"root">>;
+ref_prefix(BasePath) ->
+    erf_util:to_snake_case(
+        binary:replace(
+            string:trim(BasePath, leading, "/"), [<<"/">>, <<"-">>], <<"_">>, [global]
+        )
+    ).
+
+-spec swagger_routes(Mounts, SwaggerUI) -> StaticRoutes when
+    Mounts :: [mount(), ...],
+    SwaggerUI :: boolean(),
+    StaticRoutes :: [static_route()].
+%% @doc Serves a Swagger UI per mount, under the base path the mount is served from, so that
+%% each mount documents only its own endpoints.
+swagger_routes(_Mounts, false) ->
+    [];
+swagger_routes(Mounts, true) ->
+    IndexHTML =
+        case code:priv_dir(erf) of
+            {error, bad_name} ->
+                {error, <<"Cannot build `swagger-ui`">>};
+            Priv ->
+                filename:join([Priv, <<"swagger-ui">>, <<"index.html">>])
+        end,
+    lists:flatmap(
+        fun(#{base_path := BasePath, spec_path := SpecPath}) ->
+            [
+                {<<BasePath/binary, "/swagger">>, {file, IndexHTML}},
+                {<<BasePath/binary, "/swagger/spec.json">>, {file, SpecPath}}
+            ]
+        end,
+        Mounts
+    ).
 
 -spec log_warnings(Warnings, Step) -> ok when
     Warnings :: list(),
@@ -401,12 +813,11 @@ match_route_(RawPath, [{Route, RouteRegEx} | Routes]) ->
             {ok, Route}
     end.
 
--spec route_patterns(API, StaticRoutes, SwaggerUI) -> RoutePatterns when
+-spec route_patterns(API, StaticRoutes) -> RoutePatterns when
     API :: api(),
     StaticRoutes :: [static_route()],
-    SwaggerUI :: boolean(),
     RoutePatterns :: route_patterns().
-route_patterns(API, StaticRoutes, SwaggerUI) ->
+route_patterns(API, StaticRoutes) ->
     Acc =
         lists:map(
             fun
@@ -417,27 +828,16 @@ route_patterns(API, StaticRoutes, SwaggerUI) ->
             end,
             StaticRoutes
         ),
-    Acc1 =
-        case SwaggerUI of
-            true ->
-                [
-                    {<<"/swagger">>, <<"^/swagger$">>},
-                    {<<"/swagger/spec.json">>, <<"^/swagger/spec.json$">>}
-                    | Acc
-                ];
-            _false ->
-                Acc
-        end,
     RawRoutes = [maps:get(path, Endpoint) || Endpoint <- maps:get(endpoints, API)],
-    route_patterns(RawRoutes, Acc1).
+    route_patterns_(RawRoutes, Acc).
 
--spec route_patterns(RawRoutes, Acc) -> RoutePatterns when
+-spec route_patterns_(RawRoutes, Acc) -> RoutePatterns when
     RawRoutes :: [binary()],
     Acc :: route_patterns(),
     RoutePatterns :: route_patterns().
-route_patterns([], Acc) ->
+route_patterns_([], Acc) ->
     Acc;
-route_patterns([Route | Routes], Acc) ->
+route_patterns_([Route | Routes], Acc) ->
     RegExParts = lists:map(
         fun
             (<<"{", _Variable/binary>>) ->
@@ -452,4 +852,4 @@ route_patterns([Route | Routes], Acc) ->
             (erlang:list_to_binary([
                 <<"/">> | lists:join(<<"/">>, RegExParts)
             ]))/binary, "$">>,
-    route_patterns(Routes, [{Route, RegEx} | Acc]).
+    route_patterns_(Routes, [{Route, RegEx} | Acc]).

--- a/src/erf_conf.erl
+++ b/src/erf_conf.erl
@@ -32,6 +32,7 @@
 -type t() :: #{
     callback => module(),
     log_level => logger:level(),
+    mounts => [erf:mount(), ...],
     preprocess_middlewares => [module()],
     postprocess_middlewares => [module()],
     route_patterns => erf:route_patterns(),

--- a/src/erf_parser.erl
+++ b/src/erf_parser.erl
@@ -34,7 +34,8 @@
 -type endpoint() :: #{
     path := path(),
     parameters := [parameter()],
-    operations := [operation()]
+    operations := [operation()],
+    base_path => erf:base_path()
 }.
 -type method() :: erf:method().
 -type operation() :: #{

--- a/src/erf_router.erl
+++ b/src/erf_router.erl
@@ -29,7 +29,8 @@
 %%% TYPES
 -type t() :: erl_syntax:syntaxTree().
 -type callback() :: module().
--type generator_opts() :: #{callback := callback(), static_routes := [erf:static_route()]}.
+-type callback_spec() :: callback() | #{erf:base_path() => callback()}.
+-type generator_opts() :: #{callback := callback_spec(), static_routes := [erf:static_route()]}.
 
 %%%-----------------------------------------------------------------------------
 %%% EXTERNAL EXPORTS
@@ -212,6 +213,9 @@ handle_ast(API, #{callback := Callback} = Opts) ->
                 )
             ),
             EndpointParameters = maps:get(parameters, Endpoint),
+            EndpointCallback = resolve_callback(
+                Callback, maps:get(base_path, Endpoint, <<>>)
+            ),
             AllowedMethods = lists:map(
                 fun(Operation) ->
                     Method = erl_syntax:atom(
@@ -301,7 +305,7 @@ handle_ast(API, #{callback := Callback} = Opts) ->
                                         none,
                                         [
                                             erl_syntax:application(
-                                                erl_syntax:atom(Callback),
+                                                erl_syntax:atom(EndpointCallback),
                                                 erl_syntax:atom(
                                                     erlang:binary_to_atom(
                                                         erf_util:to_snake_case(
@@ -550,6 +554,17 @@ handle_ast(API, #{callback := Callback} = Opts) ->
         erl_syntax:atom(handle),
         RESTClauses ++ StaticClauses ++ [NotFoundClause]
     ).
+
+-spec resolve_callback(CallbackSpec, BasePath) -> Callback when
+    CallbackSpec :: callback_spec(),
+    BasePath :: erf:base_path(),
+    Callback :: callback().
+%% @doc Resolves which callback module handles a given endpoint: a single callback module is
+%% shared by every endpoint, while a map gives each mount its own module.
+resolve_callback(Callback, _BasePath) when is_atom(Callback) ->
+    Callback;
+resolve_callback(CallbacksByBasePath, BasePath) when is_map(CallbacksByBasePath) ->
+    maps:get(BasePath, CallbacksByBasePath).
 
 -spec is_valid_request(Parameters, Request) -> Result when
     Parameters :: [erf_parser:parameter()],

--- a/test/erf_mounts_SUITE.erl
+++ b/test/erf_mounts_SUITE.erl
@@ -1,0 +1,382 @@
+%%% Copyright 2023 Nomasystems, S.L. http://www.nomasystems.com
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+-module(erf_mounts_SUITE).
+
+%%% INCLUDE FILES
+-include_lib("stdlib/include/assert.hrl").
+
+%%% EXTERNAL EXPORTS
+-compile([export_all, nowarn_export_all]).
+
+%%% MACROS
+-define(PORT, 8789).
+
+%%%-----------------------------------------------------------------------------
+%%% SUITE EXPORTS
+%%%-----------------------------------------------------------------------------
+all() ->
+    [
+        single_spec_path_is_unaffected,
+        mounts_route_by_base_path,
+        isolated_validation_across_mounts,
+        swagger_ui_per_mount,
+        invalid_conf,
+        reload_conf_replaces_mounts
+    ].
+
+%%%-----------------------------------------------------------------------------
+%%% INIT SUITE EXPORTS
+%%%-----------------------------------------------------------------------------
+init_per_suite(Conf) ->
+    nct_util:setup_suite(Conf).
+
+%%%-----------------------------------------------------------------------------
+%%% END SUITE EXPORTS
+%%%-----------------------------------------------------------------------------
+end_per_suite(Conf) ->
+    nct_util:teardown_suite(Conf).
+
+%%%-----------------------------------------------------------------------------
+%%% INIT CASE EXPORTS
+%%%-----------------------------------------------------------------------------
+init_per_testcase(Case, Conf) ->
+    ct:print("Starting test case ~p", [Case]),
+    nct_util:init_traces(Case),
+    Conf.
+
+%%%-----------------------------------------------------------------------------
+%%% END CASE EXPORTS
+%%%-----------------------------------------------------------------------------
+end_per_testcase(Case, Conf) ->
+    nct_util:end_traces(Case),
+    ct:print("Test case ~p completed", [Case]),
+    Conf.
+
+%%%-----------------------------------------------------------------------------
+%%% TEST CASES
+%%%-----------------------------------------------------------------------------
+single_spec_path_is_unaffected(_Conf) ->
+    %% A plain `spec_path'/`callback' pair, the only shape `erf' has ever supported, keeps
+    %% behaving exactly as before: it is served from the root, with no prefix in its routes.
+    meck:new([erf_items_callback], [non_strict, no_link]),
+    meck:expect(erf_items_callback, list_items, fun(_Request) -> {200, [], <<"items">>} end),
+
+    {ok, _Pid} = erf:start_link(#{
+        spec_path => spec(<<"mount_items_oas_3_0_spec.json">>),
+        callback => erf_items_callback,
+        port => ?PORT,
+        name => erf_server
+    }),
+
+    ?assertMatch({200, <<"\"items\"">>}, http_get("/items")),
+    ?assertMatch({404, _Body}, http_get("/v1/items")),
+    ?assertMatch({ok, <<"/items">>}, erf:match_route(erf_server, <<"/items">>)),
+
+    %% The stored configuration still reads back the keys it was given, so anything
+    %% inspecting it through `erf_conf:get/1' keeps working untouched.
+    {ok, StoredConf} = erf_conf:get(erf_server),
+    ?assertEqual(spec(<<"mount_items_oas_3_0_spec.json">>), maps:get(spec_path, StoredConf)),
+    ?assertEqual(erf_items_callback, maps:get(callback, StoredConf)),
+
+    %% And so does a reload that carries no specification config of its own.
+    ok = erf:reload_conf(erf_server, #{log_level => warning}),
+    ?assertMatch({200, <<"\"items\"">>}, http_get("/items")),
+
+    ok = erf:stop(erf_server),
+    meck:unload(erf_items_callback),
+    ok.
+
+mounts_route_by_base_path(_Conf) ->
+    %% Three mounts on a single port: the same specification served both from the
+    %% root and from `/v1', and an unrelated one served from `/shop'. Each one dispatches to
+    %% its own callback module, and the callbacks see the real, prefixed path.
+    meck:new([erf_items_callback, erf_items_v1_callback, erf_orders_callback], [
+        non_strict, no_link
+    ]),
+    meck:expect(erf_items_callback, list_items, fun(_Request) -> {200, [], <<"root">>} end),
+    meck:expect(erf_items_v1_callback, list_items, fun(_Request) -> {200, [], <<"v1">>} end),
+    meck:expect(erf_orders_callback, list_orders, fun(#{path := Path}) ->
+        {200, [], erlang:iolist_to_binary(lists:join(<<"/">>, Path))}
+    end),
+    meck:expect(erf_orders_callback, get_order, fun(#{path_parameters := PathParameters}) ->
+        {200, [], proplists:get_value(<<"id">>, PathParameters)}
+    end),
+
+    {ok, _Pid} = erf:start_link(#{
+        mounts => [
+            #{
+                base_path => <<"/">>,
+                spec_path => spec(<<"mount_items_oas_3_0_spec.json">>),
+                callback => erf_items_callback
+            },
+            #{
+                base_path => <<"/v1">>,
+                spec_path => spec(<<"mount_items_oas_3_0_spec.json">>),
+                callback => erf_items_v1_callback
+            },
+            #{
+                base_path => <<"/shop">>,
+                spec_path => spec(<<"mount_orders_oas_3_0_spec.json">>),
+                callback => erf_orders_callback
+            }
+        ],
+        port => ?PORT,
+        name => erf_server
+    }),
+
+    ?assertMatch({200, <<"\"root\"">>}, http_get("/items")),
+    ?assertMatch({200, <<"\"v1\"">>}, http_get("/v1/items")),
+    ?assertMatch({200, <<"\"shop/orders\"">>}, http_get("/shop/orders")),
+    ?assertMatch({200, <<"\"42\"">>}, http_get("/shop/orders/42")),
+
+    %% Only the mounted routes exist: the orders specification is not served from the root.
+    ?assertMatch({404, _Body}, http_get("/orders")),
+    ?assertMatch({404, _Body2}, http_get("/v2/items")),
+
+    ?assertMatch(
+        {ok, <<"/shop/orders/{id}">>}, erf:match_route(erf_server, <<"/shop/orders/42">>)
+    ),
+
+    ok = erf:stop(erf_server),
+    meck:unload([erf_items_callback, erf_items_v1_callback, erf_orders_callback]),
+    ok.
+
+isolated_validation_across_mounts(_Conf) ->
+    %% Two specifications that share a file name, and therefore the schema names the parser
+    %% generates from them, define an incompatible `Entry'. Each mount must validate against
+    %% its own, so a body accepted by one is rejected by the other.
+    meck:new([erf_catalog_a_callback, erf_catalog_b_callback], [non_strict, no_link]),
+    meck:expect(erf_catalog_a_callback, create_entry, fun(_Request) -> {201, [], <<"a">>} end),
+    meck:expect(erf_catalog_b_callback, create_entry, fun(_Request) -> {201, [], <<"b">>} end),
+
+    {ok, _Pid} = erf:start_link(#{
+        mounts => [
+            #{
+                base_path => <<"/a">>,
+                spec_path => spec(<<"mount_a/catalog_oas_3_0_spec.json">>),
+                callback => erf_catalog_a_callback
+            },
+            #{
+                base_path => <<"/b">>,
+                spec_path => spec(<<"mount_b/catalog_oas_3_0_spec.json">>),
+                callback => erf_catalog_b_callback
+            }
+        ],
+        port => ?PORT,
+        name => erf_server
+    }),
+
+    NamedEntry = <<"{\"name\":\"an entry\"}">>,
+    ReferencedEntry = <<"{\"reference\":\"an entry\"}">>,
+
+    ?assertMatch({201, <<"\"a\"">>}, post("/a/entries", NamedEntry)),
+    ?assertMatch({400, _Body}, post("/a/entries", ReferencedEntry)),
+
+    ?assertMatch({201, <<"\"b\"">>}, post("/b/entries", ReferencedEntry)),
+    ?assertMatch({400, _Body2}, post("/b/entries", NamedEntry)),
+
+    ok = erf:stop(erf_server),
+    meck:unload([erf_catalog_a_callback, erf_catalog_b_callback]),
+    ok.
+
+swagger_ui_per_mount(_Conf) ->
+    %% Every mount documents only itself, under the base path it is served from.
+    meck:new([erf_items_callback, erf_orders_callback], [non_strict, no_link]),
+
+    {ok, _Pid} = erf:start_link(#{
+        mounts => [
+            #{
+                base_path => <<"/">>,
+                spec_path => spec(<<"mount_items_oas_3_0_spec.json">>),
+                callback => erf_items_callback
+            },
+            #{
+                base_path => <<"/shop">>,
+                spec_path => spec(<<"mount_orders_oas_3_0_spec.json">>),
+                callback => erf_orders_callback
+            }
+        ],
+        swagger_ui => true,
+        port => ?PORT,
+        name => erf_server
+    }),
+
+    ?assertMatch({200, _IndexHTML}, http_get("/swagger")),
+    ?assertMatch({200, _ShopIndexHTML}, http_get("/shop/swagger")),
+
+    {200, RootSpec} = http_get("/swagger/spec.json"),
+    ?assertMatch(#{<<"paths">> := #{<<"/items">> := _Items}}, json:decode(RootSpec)),
+
+    {200, ShopSpec} = http_get("/shop/swagger/spec.json"),
+    ?assertMatch(#{<<"paths">> := #{<<"/orders">> := _Orders}}, json:decode(ShopSpec)),
+
+    ok = erf:stop(erf_server),
+    meck:unload([erf_items_callback, erf_orders_callback]),
+    ok.
+
+invalid_conf(_Conf) ->
+    %% Configuration errors are reported instead of silently producing a router where one
+    %% mount shadows another.
+    meck:new([erf_items_callback], [non_strict, no_link]),
+
+    {ok, _Pid} = erf:start_link(#{
+        spec_path => spec(<<"mount_items_oas_3_0_spec.json">>),
+        callback => erf_items_callback,
+        port => ?PORT,
+        name => erf_server
+    }),
+
+    ItemsMount = #{
+        base_path => <<"/v1">>,
+        spec_path => spec(<<"mount_items_oas_3_0_spec.json">>),
+        callback => erf_items_callback
+    },
+
+    ?assertEqual(
+        {error, {invalid_conf, mounts_and_spec_path}},
+        erf:reload_conf(erf_server, #{
+            mounts => [ItemsMount],
+            spec_path => spec(<<"mount_items_oas_3_0_spec.json">>)
+        })
+    ),
+
+    ?assertEqual(
+        {error, {duplicate_base_path, <<"/v1">>}},
+        erf:reload_conf(erf_server, #{mounts => [ItemsMount, ItemsMount#{callback => other}]})
+    ),
+
+    %% The orders mount serves `/orders/{id}', which would shadow the `/orders/items'
+    %% of an items mount under `/orders'.
+    ?assertEqual(
+        {error, {conflicting_routes, <<"/orders/items">>, <<"/orders/{id}">>}},
+        erf:reload_conf(erf_server, #{
+            mounts => [
+                ItemsMount#{base_path => <<"/orders">>},
+                #{
+                    base_path => <<"/">>,
+                    spec_path => spec(<<"mount_orders_oas_3_0_spec.json">>),
+                    callback => erf_items_callback
+                }
+            ]
+        })
+    ),
+
+    ?assertEqual(
+        {error, {invalid_base_path, <<"/{tenant}">>}},
+        erf:reload_conf(erf_server, #{mounts => [ItemsMount#{base_path => <<"/{tenant}">>}]})
+    ),
+
+    %% None of the rejected configurations replaced the running one.
+    ?assertMatch({ok, <<"/items">>}, erf:match_route(erf_server, <<"/items">>)),
+
+    ok = erf:stop(erf_server),
+    meck:unload(erf_items_callback),
+    ok.
+
+reload_conf_replaces_mounts(_Conf) ->
+    %% A reload carrying `mounts' swaps the whole set of mounts.
+    meck:new([erf_items_callback, erf_orders_callback], [non_strict, no_link]),
+    meck:expect(erf_items_callback, list_items, fun(_Request) -> {200, [], <<"items">>} end),
+    meck:expect(erf_orders_callback, list_orders, fun(_Request) -> {200, [], <<"orders">>} end),
+
+    {ok, _Pid} = erf:start_link(#{
+        mounts => [
+            #{
+                base_path => <<"/v1">>,
+                spec_path => spec(<<"mount_items_oas_3_0_spec.json">>),
+                callback => erf_items_callback
+            }
+        ],
+        port => ?PORT,
+        name => erf_server
+    }),
+
+    ?assertMatch({200, <<"\"items\"">>}, http_get("/v1/items")),
+    ?assertMatch({404, _Body}, http_get("/shop/orders")),
+
+    ok = erf:reload_conf(erf_server, #{
+        mounts => [
+            #{
+                base_path => <<"/shop">>,
+                spec_path => spec(<<"mount_orders_oas_3_0_spec.json">>),
+                callback => erf_orders_callback
+            }
+        ]
+    }),
+
+    ?assertMatch({200, <<"\"orders\"">>}, http_get("/shop/orders")),
+    ?assertMatch({404, _Body2}, http_get("/v1/items")),
+
+    %% A reload bringing no specification config keeps the mounts in place.
+    ok = erf:reload_conf(erf_server, #{log_level => warning}),
+    ?assertMatch({200, <<"\"orders\"">>}, http_get("/shop/orders")),
+
+    %% An instance with several mounts has no single mount for a bare `callback' to patch.
+    ok = erf:reload_conf(erf_server, #{
+        mounts => [
+            #{
+                base_path => <<"/shop">>,
+                spec_path => spec(<<"mount_orders_oas_3_0_spec.json">>),
+                callback => erf_orders_callback
+            },
+            #{
+                base_path => <<"/v1">>,
+                spec_path => spec(<<"mount_items_oas_3_0_spec.json">>),
+                callback => erf_items_callback
+            }
+        ]
+    }),
+    ?assertEqual(
+        {error, {invalid_conf, ambiguous_mount_patch}},
+        erf:reload_conf(erf_server, #{callback => erf_items_callback})
+    ),
+
+    %% But `spec_path' and `callback' together describe a whole instance, so they replace the
+    %% mounts and take it back to serving a single specification from the root.
+    ok = erf:reload_conf(erf_server, #{
+        spec_path => spec(<<"mount_items_oas_3_0_spec.json">>),
+        callback => erf_items_callback
+    }),
+    ?assertMatch({200, <<"\"items\"">>}, http_get("/items")),
+    ?assertMatch({404, _Body3}, http_get("/v1/items")),
+    {ok, BackToSingle} = erf_conf:get(erf_server),
+    ?assertEqual(erf_items_callback, maps:get(callback, BackToSingle)),
+
+    ok = erf:stop(erf_server),
+    meck:unload([erf_items_callback, erf_orders_callback]),
+    ok.
+
+%%%-----------------------------------------------------------------------------
+%%% INTERNAL FUNCTIONS
+%%%-----------------------------------------------------------------------------
+spec(Fixture) ->
+    filename:join([code:lib_dir(erf), "test", <<"fixtures/", Fixture/binary>>]).
+
+url(Path) ->
+    "http://localhost:" ++ erlang:integer_to_list(?PORT) ++ Path.
+
+http_get(Path) ->
+    {ok, {{_HTTPVersion, Status, _Reason}, _Headers, Body}} = httpc:request(
+        get, {url(Path), []}, [], [{body_format, binary}]
+    ),
+    {Status, Body}.
+
+post(Path, Body) ->
+    {ok, {{_HTTPVersion, Status, _Reason}, _Headers, ResponseBody}} = httpc:request(
+        post,
+        {url(Path), [], "application/json", Body},
+        [],
+        [{body_format, binary}]
+    ),
+    {Status, ResponseBody}.

--- a/test/fixtures/mount_a/catalog_oas_3_0_spec.json
+++ b/test/fixtures/mount_a/catalog_oas_3_0_spec.json
@@ -1,0 +1,55 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "A catalog",
+        "license": {
+            "name": "Apache 2.0"
+        }
+    },
+    "paths": {
+        "/entries": {
+            "post": {
+                "summary": "Create an entry",
+                "operationId": "createEntry",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Entry"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Entry"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Entry": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            }
+        }
+    }
+}

--- a/test/fixtures/mount_b/catalog_oas_3_0_spec.json
+++ b/test/fixtures/mount_b/catalog_oas_3_0_spec.json
@@ -1,0 +1,55 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "B catalog",
+        "license": {
+            "name": "Apache 2.0"
+        }
+    },
+    "paths": {
+        "/entries": {
+            "post": {
+                "summary": "Create an entry",
+                "operationId": "createEntry",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Entry"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Entry"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Entry": {
+                "type": "object",
+                "properties": {
+                    "reference": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "reference"
+                ]
+            }
+        }
+    }
+}

--- a/test/fixtures/mount_items_oas_3_0_spec.json
+++ b/test/fixtures/mount_items_oas_3_0_spec.json
@@ -1,0 +1,74 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Items mount",
+        "license": {
+            "name": "Apache 2.0"
+        }
+    },
+    "paths": {
+        "/items": {
+            "get": {
+                "summary": "List items",
+                "operationId": "listItems",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Item"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "summary": "Create an item",
+                "operationId": "createItem",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Item"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Item"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Item": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            }
+        }
+    }
+}

--- a/test/fixtures/mount_orders_oas_3_0_spec.json
+++ b/test/fixtures/mount_orders_oas_3_0_spec.json
@@ -1,0 +1,77 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Orders mount",
+        "license": {
+            "name": "Apache 2.0"
+        }
+    },
+    "paths": {
+        "/orders": {
+            "get": {
+                "summary": "List orders",
+                "operationId": "listOrders",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": "#/components/schemas/Order"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/orders/{id}": {
+            "parameters": [
+                {
+                    "in": "path",
+                    "name": "id",
+                    "schema": {
+                        "type": "string"
+                    },
+                    "required": true,
+                    "description": "Order's identifier"
+                }
+            ],
+            "get": {
+                "summary": "Get an order",
+                "operationId": "getOrder",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Order"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Order": {
+                "type": "object",
+                "properties": {
+                    "reference": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "reference"
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
 Closes #96 .

 Lets a single `erf` instance serve several API specifications on one port, each under its own base path:

  ```erl
  mounts => [
      #{base_path => <<"/users">>, 
        spec_path => <<"priv/users.json">>, 
        callback => users_callback},
      #{base_path => <<"/products">>, 
        spec_path => <<"priv/products.json">>, 
        callback => products_callback}
  ]
  ```